### PR TITLE
Add multiple SQL database support (SQLite, MySQL, Postgres)

### DIFF
--- a/src/routes/admin/registration_key.rs
+++ b/src/routes/admin/registration_key.rs
@@ -47,7 +47,7 @@ async fn create(
 ) -> Response<impl Responder> {
     Ok(HttpResponse::Ok().json(RegistrationKeyData::from(
         registration_keys::ActiveModel {
-            iss_user: Set(user.id.to_owned()),
+            issueru: Set(user.id.to_owned()),
             uses_left: Set(query.max_uses.unwrap_or(1)),
             ..Default::default()
         }


### PR DESCRIPTION
This adds support for multiple databases and keeps compatibility with all of them by using a platform agnostic migration toolkit and ORM (SeaORM).

## Changes
- Regenerated entities.
- Converted SQL migrations to code migrations.
- Added a guide on generating entities.
- Removed all raw SQL queries (except version query).